### PR TITLE
Don't restrict symfony/symfony packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^7.1",
         "symfony/serializer-pack": "*",
-        "symfony/messenger": "^4.1",
+        "symfony/messenger": "*",
         "ext-amqp": "*"
     }
 }


### PR DESCRIPTION
will allow "unpack" to replace the wildcard by what's in extra.symfony.require also (PR to come)